### PR TITLE
Add php7-ldap package to support LDAP authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN \
 	imagemagick \
 	php7-bz2 \
 	php7-gd \
+	php7-ldap \
 	php7-xml \
 	php7-zip && \
  echo "**** install dokuwiki ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -18,6 +18,7 @@ RUN \
 	imagemagick \
 	php7-bz2 \
 	php7-gd \
+	php7-ldap \
 	php7-xml \
 	php7-zip && \
  echo "**** install dokuwiki ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -18,6 +18,7 @@ RUN \
 	imagemagick \
 	php7-bz2 \
 	php7-gd \
+	php7-ldap \
 	php7-xml \
 	php7-zip && \
  echo "**** install dokuwiki ****" && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,4 +40,5 @@ app_setup_block: |
   Upon first install go to `http://$IP:$PORT/install.php` once you have completed the setup, restart the container, login as admin and set "Use nice URLs" in the `admin/Configuration Settings` panel to `.htaccess` and tick `Use slash as namespace separator in URLs` to enable [nice URLs](https://www.dokuwiki.org/rewrite) you will find the webui at `http://$IP:$PORT/`, for more info see [{{ project_name|capitalize }}]({{ project_url }})
 # changelog
 changelogs:
+  - { date: "01.12.19:", desc: "Add php7-ldap package to support LDAP authentication." }
   - { date: "28.05.19:", desc: "Initial Release." }


### PR DESCRIPTION
Adds the installation of the `php7-ldap` package to the Dockerfiles in order to support LDAP authentication.

------------------------------

## Description:
Adds the installation of the `php7-ldap` package to all three Dockerfiles in order to support LDAP authentication.

## Benefits of this PR and context:
Dokuwiki comes pre-installed with a plugin that allows authentication via LDAP. In order for the LDAP plugin to work the `php7-ldap` package is required on a system level.

## How Has This Been Tested?
I didn't build the docker image (not a docker expert) but simply SSHed into the container and executed the very same command to install the missing package.

## Source / References:
Closes #6 