### PR TITLE
Various updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:3.11
+FROM lsiobase/nginx:3.12
 
 # set version label
 ARG BUILD_DATE
@@ -18,8 +18,13 @@ RUN \
 	imagemagick \
 	php7-bz2 \
 	php7-ctype \
+	php7-curl \
 	php7-gd \
+	php7-iconv \
 	php7-ldap \
+	php7-pecl-imagick \
+	php7-pdo_mysql \
+	php7-pdo_pgsql \
 	php7-xml \
 	php7-zip && \
  echo "**** install dokuwiki ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.11
+FROM lsiobase/nginx:arm64v8-3.12
 
 # set version label
 ARG BUILD_DATE
@@ -18,8 +18,13 @@ RUN \
 	imagemagick \
 	php7-bz2 \
 	php7-ctype \
+	php7-curl \
 	php7-gd \
+	php7-iconv \
 	php7-ldap \
+	php7-pecl-imagick \
+	php7-pdo_mysql \
+	php7-pdo_pgsql \
 	php7-xml \
 	php7-zip && \
  echo "**** install dokuwiki ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm32v7-3.11
+FROM lsiobase/nginx:arm32v7-3.12
 
 # set version label
 ARG BUILD_DATE
@@ -18,8 +18,13 @@ RUN \
 	imagemagick \
 	php7-bz2 \
 	php7-ctype \
+	php7-curl \
 	php7-gd \
+	php7-iconv \
 	php7-ldap \
+	php7-pecl-imagick \
+	php7-pdo_mysql \
+	php7-pdo_pgsql \
 	php7-xml \
 	php7-zip && \
  echo "**** install dokuwiki ****" && \

--- a/README.md
+++ b/README.md
@@ -67,10 +67,9 @@ docker create \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Europe/London \
-  -e APP_URL=/dokuwiki `#optional` \
   -p 80:80 \
   -p 443:443 `#optional` \
-  -v </path/to/appdata/config>:/config \
+  -v /path/to/appdata/config:/config \
   --restart unless-stopped \
   linuxserver/dokuwiki
 ```
@@ -91,9 +90,8 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
-      - APP_URL=/dokuwiki #optional
     volumes:
-      - </path/to/appdata/config>:/config
+      - /path/to/appdata/config:/config
     ports:
       - 80:80
       - 443:443 #optional
@@ -111,7 +109,6 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
-| `-e APP_URL=/dokuwiki` | Specify an APP_URL to append to your root location, helpful for subfolder reverse proxy setups.  Does not take effect until after first restart following setup. |
 | `-v /config` | Configuration files. |
 
 ## Environment variables from files (Docker secrets)
@@ -221,6 +218,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **14.09.20:** - Rebase to alpine 3.12. Add php7-ctype, php7-curl, php7-pdo_mysql, php7-pdo_pgsql, php7-pecl-imagick and php7-iconv. Bump upload max filesize and post max size to 100MB. Remove deprecated APP_URL env var.
 * **19.12.19:** - Rebasing to alpine 3.11.
 * **01.12.19:** - Add php7-ldap package to support LDAP authentication.
 * **28.05.19:** - Initial Release.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **14.09.20:** - Rebase to alpine 3.12. Add php7-ctype, php7-curl, php7-pdo_mysql, php7-pdo_pgsql, php7-pecl-imagick and php7-iconv. Bump upload max filesize and post max size to 100MB. Remove deprecated APP_URL env var.
+* **14.09.20:** - Rebase to alpine 3.12. Add php7-ctype, php7-curl, php7-pdo_mysql, php7-pdo_pgsql, php7-pecl-imagick and php7-iconv. Bump upload max filesize and post max size to 100MB. Remove deprecated APP_URL env var. Fix breaking addons.
 * **19.12.19:** - Rebasing to alpine 3.11.
 * **01.12.19:** - Add php7-ldap package to support LDAP authentication.
 * **28.05.19:** - Initial Release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,7 +40,7 @@ app_setup_block: |
   Upon first install go to `http://$IP:$PORT/install.php` once you have completed the setup, restart the container, login as admin and set "Use nice URLs" in the `admin/Configuration Settings` panel to `.htaccess` and tick `Use slash as namespace separator in URLs` to enable [nice URLs](https://www.dokuwiki.org/rewrite) you will find the webui at `http://$IP:$PORT/`, for more info see [{{ project_name|capitalize }}]({{ project_url }})
 # changelog
 changelogs:
-  - { date: "14.09.20:", desc: "Rebase to alpine 3.12. Add php7-ctype, php7-curl, php7-pdo_mysql, php7-pdo_pgsql, php7-pecl-imagick and php7-iconv. Bump upload max filesize and post max size to 100MB. Remove deprecated APP_URL env var."}
+  - { date: "14.09.20:", desc: "Rebase to alpine 3.12. Add php7-ctype, php7-curl, php7-pdo_mysql, php7-pdo_pgsql, php7-pecl-imagick and php7-iconv. Bump upload max filesize and post max size to 100MB. Remove deprecated APP_URL env var. Fix breaking addons."}
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "01.12.19:", desc: "Add php7-ldap package to support LDAP authentication." }
   - { date: "28.05.19:", desc: "Initial Release." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -22,13 +22,13 @@ param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
 param_usage_include_vols: true
 param_volumes:
-  - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Configuration files." }
+  - { vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Configuration files." }
 param_usage_include_ports: true
 param_ports:
   - { external_port: "80", internal_port: "80", port_desc: "Application HTTP Port" }
 
 # optional container parameters
-opt_param_usage_include_env: true
+opt_param_usage_include_env: false
 opt_param_env_vars:
   - { env_var: "APP_URL", env_value: "/dokuwiki", desc: "Specify an APP_URL to append to your root location, helpful for subfolder reverse proxy setups.  Does not take effect until after first restart following setup." }
 opt_param_usage_include_ports: true
@@ -40,7 +40,7 @@ app_setup_block: |
   Upon first install go to `http://$IP:$PORT/install.php` once you have completed the setup, restart the container, login as admin and set "Use nice URLs" in the `admin/Configuration Settings` panel to `.htaccess` and tick `Use slash as namespace separator in URLs` to enable [nice URLs](https://www.dokuwiki.org/rewrite) you will find the webui at `http://$IP:$PORT/`, for more info see [{{ project_name|capitalize }}]({{ project_url }})
 # changelog
 changelogs:
-  - { date: "13.06.20:", desc: "Add php7-ctype package to support mdpage plugin."}
+  - { date: "14.09.20:", desc: "Rebase to alpine 3.12. Add php7-ctype, php7-curl, php7-pdo_mysql, php7-pdo_pgsql, php7-pecl-imagick and php7-iconv. Bump upload max filesize and post max size to 100MB. Remove deprecated APP_URL env var."}
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "01.12.19:", desc: "Add php7-ldap package to support LDAP authentication." }
   - { date: "28.05.19:", desc: "Initial Release." }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -8,8 +8,8 @@ server {
 	ssl_certificate /config/keys/cert.crt;
 	ssl_certificate_key /config/keys/cert.key;
 
-    # Maximum file upload size is 4MB - change accordingly if needed
-    client_max_body_size 4M;
+    # Maximum file upload size is 100MB - change accordingly if needed
+    client_max_body_size 100M;
     client_body_buffer_size 128k;
 
     root /app/dokuwiki;

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -9,7 +9,7 @@ USER_DIRECTORY=(\
     "data/meta" \
     "data/pages" \
     "lib/plugins" \
-    "lib/tpl" \
+    "lib/tpl"
     )
 
 ## Make data directories
@@ -22,12 +22,13 @@ USER_DIRECTORY=(\
 ## Move user folders to persistent storage
 for i in "${USER_DIRECTORY[@]}"; do 
     [[ ! -d /config/dokuwiki/${i} ]] && \
+        [[ -d /app/dokuwiki/"${i}" ]] && \
         mv /app/dokuwiki/"${i}" /config/dokuwiki/"${i}"/
 done
 
 ## Remove user folders
 for i in "${USER_DIRECTORY[@]}"; do 
-[[  -d /app/dokuwiki/"${i}" ]] && \
+[[ -d /app/dokuwiki/"${i}" ]] && \
     rm -rf /app/dokuwiki/"${i}"
 done
 
@@ -37,9 +38,13 @@ for i in "${USER_DIRECTORY[@]}"; do
     ln -s /config/dokuwiki/"${i}" /app/dokuwiki/"${i}"
 done
 
+## Bump php upload max filesize and post max size to 100MB by default
+grep -qxF 'upload_max_filesize' /config/php/php-local.ini || echo 'upload_max_filesize = 100MB' >> /config/php/php-local.ini
+grep -qxF 'post_max_size' /config/php/php-local.ini || echo 'post_max_size = 100MB' >> /config/php/php-local.ini
+
 ## Remove install.php once setup & enable pretty urls to work after setting .htaccess method in admin panel.
 if [[ -f /config/dokuwiki/conf/local.php ]]; then
-    rm /app/dokuwiki/install.php && \
+    rm -rf /app/dokuwiki/install.php && \
     sed -i -e 's/#location/location/g' \
         /config/nginx/site-confs/default && \
     echo "Existing install found install.php not available"


### PR DESCRIPTION
Rebase to alpine 3.12. 
Add php7-ctype, php7-curl, php7-pdo_mysql, php7-pdo_pgsql, php7-pecl-imagick and php7-iconv. 
Bump upload max filesize and post max size to 100MB. 
Remove deprecated APP_URL env var. 
Fix breaking addons.

closes #9 
closes #12 
closes #13 
closes #17 
closes #19 
closes #20 