### PR TITLE
Issue 27: store search index outside of container and set absolute (default) path for 'savedir'

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ app_setup_block: |
   Upon first install go to `http://$IP:$PORT/install.php` once you have completed the setup, restart the container, login as admin and set "Use nice URLs" in the `admin/Configuration Settings` panel to `.htaccess` and tick `Use slash as namespace separator in URLs` to enable [nice URLs](https://www.dokuwiki.org/rewrite) you will find the webui at `http://$IP:$PORT/`, for more info see [{{ project_name|capitalize }}]({{ project_url }})
 # changelog
 changelogs:
+  - { date: "21.02.21:", desc: "Store search index outside of container, set absolute (default) path for `savedir`." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "28.09.20:", desc: "Add php7-pdo_sqlite and php7-sqlite3." }
   - { date: "23.09.20:", desc: "Fix php-local.ini bug introduced in the prior PR." }

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -3,6 +3,7 @@
 USER_DIRECTORY=(\
     "conf" \
     "data/attic" \
+    "data/index" \
     "data/media" \
     "data/media_attic" \
     "data/media_meta" \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -67,6 +67,12 @@ if [[ -f /config/dokuwiki/conf/local.php ]]; then
     sed -i -e 's/#location/location/g' \
         /config/nginx/site-confs/default && \
     echo "Existing install found install.php not available"
+
+    # when default savedir stil active: change it to the path IN the container
+    if ! grep -q "^\$conf\[\'savedir\'\]\s*\=" /config/dokuwiki/conf/local.php; then
+        echo "Set 'savedir' to absolute path in the container"
+        echo "\$conf['savedir'] = '/app/dokuwiki/data';" >> /config/dokuwiki/conf/local.php
+    fi
 else
     echo "Go to http://IP-ADDRESS:PORT/install.php to configure your install then restart your container when finished to remove install.php"
 fi


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-dokuwiki/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------
## Description:
The search index is created inside the container: when the container is upgraded the index will be removed and search is broken. If you try to rebuild the index using the [Searchindex Manager](https://www.dokuwiki.org/plugin:searchindex) you get another error: (existing) directories are not found and as a consequence you cannot rebuild the index. This PR fixes both issues and thereby closes #27.

## Benefits of this PR and context:
This fixes an outstanding bug and closes #27.

## How Has This Been Tested?
The change has been tested by:

- Install new container from remote docker-dokuwiki.
- Run install.php and restart container.
- Create a page and test search: works.
- Remove container and create/start a new one from the remote docker-dokuwiki image.
- Test search: broken.
- Install and try to rebuild the search index using the [Searchindex Manager](https://www.dokuwiki.org/plugin:searchindex): does not work, complains about missing path.
- Build new (local) image from this PR.
- Remove container and create/start a new one from the local build.
- Test search: still broken (as expected)
- Rebuild index using [Searchindex Manager](https://www.dokuwiki.org/plugin:searchindex): this now works.
- Test search: works as expected.
- Again: remove container and create/start a new one from the local build.
- Test search: still works as expected.

## Source / References:
See issue #27.
