### PR TITLE
Add php7-dom extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
 	php7-bz2 \
 	php7-ctype \
 	php7-curl \
+	php7-dom \
 	php7-gd \
 	php7-iconv \
 	php7-ldap \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -19,6 +19,7 @@ RUN \
 	php7-bz2 \
 	php7-ctype \
 	php7-curl \
+	php7-dom \
 	php7-gd \
 	php7-iconv \
 	php7-ldap \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -19,6 +19,7 @@ RUN \
 	php7-bz2 \
 	php7-ctype \
 	php7-curl \
+	php7-dom \
 	php7-gd \
 	php7-iconv \
 	php7-ldap \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ app_setup_block: |
   Upon first install go to `http://$IP:$PORT/install.php` once you have completed the setup, restart the container, login as admin and set "Use nice URLs" in the `admin/Configuration Settings` panel to `.htaccess` and tick `Use slash as namespace separator in URLs` to enable [nice URLs](https://www.dokuwiki.org/rewrite) you will find the webui at `http://$IP:$PORT/`, for more info see [{{ project_name|capitalize }}]({{ project_url }})
 # changelog
 changelogs:
+  - { date: "20.07.21:", desc: "Add php7-dom, fixes minor issues in sprintdoc template." }
   - { date: "15.04.21:", desc: "Add `vendor` folder to deny list." }
   - { date: "21.02.21:", desc: "Store search index outside of container, set absolute (default) path for `savedir`." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }


### PR DESCRIPTION
## Description:
Fixes plugins using dom methods, which may expect it because normal php by default is compiled with dom methods on.

In practice this fixes minor issues in the popular sprintdoc template.

## Benefits of this PR and context:
Fixes https://github.com/cosmocode/dokuwiki-template-sprintdoc/issues/65

## How Has This Been Tested?
Only tested and validated on an x86_64 machine.

## Source / References:
sprintdoc: https://www.dokuwiki.org/template:sprintdoc
missing function: https://www.php.net/manual/en/function.dom-import-simplexml.php
