### PR TITLE
Persist smileys/local and interwiki image folders outside of container

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ app_setup_block: |
   Upon first install go to `http://$IP:$PORT/install.php` once you have completed the setup, restart the container, login as admin and set "Use nice URLs" in the `admin/Configuration Settings` panel to `.htaccess` and tick `Use slash as namespace separator in URLs` to enable [nice URLs](https://www.dokuwiki.org/rewrite) you will find the webui at `http://$IP:$PORT/`, for more info see [{{ project_name|capitalize }}]({{ project_url }})
 # changelog
 changelogs:
+  - { date: "11.13.22:", desc: "Move lib/images/smileys/local and lib/images/interwiki outside of the container for user defined smiley and interwiki icon support." }
   - { date: "20.08.22:", desc: "Rebasing to alpine 3.15 with php8. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base))." }
   - { date: "20.07.21:", desc: "Add php7-dom, fixes minor issues in sprintdoc template." }
   - { date: "15.04.21:", desc: "Add `vendor` folder to deny list." }

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -4,15 +4,15 @@ USER_DIRECTORY=(\
     "conf" \
     "data/attic" \
     "data/index" \
-    "data/media" \
     "data/media_attic" \
     "data/media_meta" \
+    "data/media" \
     "data/meta" \
     "data/pages" \
-    "lib/plugins" \
-    "lib/tpl" \
+    "lib/images/interwiki" \
     "lib/images/smileys/local" \
-    "lib/images/interwiki"
+    "lib/plugins" \
+    "lib/tpl"
     )
 
 CORE_DIR=(\
@@ -25,12 +25,8 @@ if [[ ! -d /config/dokuwiki/data ]]; then
     mkdir -p /config/dokuwiki/data
 fi
 
-if [[ ! -d /config/dokuwiki/lib/ ]]; then
-    mkdir -p /config/dokuwiki/lib/
-fi
-
-if [[ ! -d /config/dokuwiki/lib/images/ ]]; then
-    mkdir -p /config/dokuwiki/lib/images/
+if [[ ! -d /config/dokuwiki/lib/images/smileys ]]; then
+    mkdir -p /config/dokuwiki/lib/images/smileys
 fi
 
 ## Move user folders to persistent storage

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -26,7 +26,7 @@ if [[ ! -d /config/dokuwiki/data ]]; then
 fi
 
 if [[ ! -d /config/dokuwiki/lib/images/smileys ]]; then
-    mkdir -p /config/dokuwiki/lib/images/smileys
+    mkdir -p /config/dokuwiki/lib/images/smileys/local
 fi
 
 ## Move user folders to persistent storage

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -21,14 +21,17 @@ CORE_DIR=(\
     )
 
 ## Make data directories
-[[ ! -d /config/dokuwiki/data ]]
+if [[ ! -d /config/dokuwiki/data ]]; then
     mkdir -p /config/dokuwiki/data
+fi
 
-[[ ! -d /config/dokuwiki/lib/ ]]
+if [[ ! -d /config/dokuwiki/lib/ ]]; then
     mkdir -p /config/dokuwiki/lib/
+fi
 
-[[ ! -d /config/dokuwiki/lib/images/ ]]
+if [[ ! -d /config/dokuwiki/lib/images/ ]]; then
     mkdir -p /config/dokuwiki/lib/images/
+fi
 
 ## Move user folders to persistent storage
 for i in "${USER_DIRECTORY[@]}"; do

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -10,7 +10,9 @@ USER_DIRECTORY=(\
     "data/meta" \
     "data/pages" \
     "lib/plugins" \
-    "lib/tpl"
+    "lib/tpl" \
+    "lib/images/smileys/local" \
+    "lib/images/interwiki"
     )
 
 CORE_DIR=(\
@@ -24,6 +26,9 @@ CORE_DIR=(\
 
 [[ ! -d /config/dokuwiki/lib/ ]]
     mkdir -p /config/dokuwiki/lib/
+
+[[ ! -d /config/dokuwiki/lib/images/ ]]
+    mkdir -p /config/dokuwiki/lib/images/
 
 ## Move user folders to persistent storage
 for i in "${USER_DIRECTORY[@]}"; do


### PR DESCRIPTION
Fixes custom smiley and interwiki icon support

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]




<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-dokuwiki/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Following the official DokuWiki documentation for working with custom smileys (https://www.dokuwiki.org/smileys) and interwiki icons (https://www.dokuwiki.org/interwiki) does not result in the custom icons being displayed. This is because the folders the user is supposed to put the icons into are not properly persisted outside of the docker container. This PR modifies the `50-config` file to make these locations persistent.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This fixes an outstanding bug and closes #40.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The change has been tested by:


  * Install a new container from the remote docker-dokuwiki
  * Run install.php and restart the container
  * Create a smileys/local folder as described in the official documentation: https://www.dokuwiki.org/smileys
    * `config/dokuwiki/lib/images/smileys/local`
  * Copy one of the user provided smileys from https://www.dokuwiki.org/_media/wiki:usersmileys:button-danger-yellow.png
  * Rename it test.png and put it in the `config/dokuwiki/lib/images/smileys/local` folder
  * Create a `config/dokuwiki/conf/smileys.local.conf` file 
```
# Testing Smileys
:SMILEYTEST:                local/test.png
```
  * Create/edit a page in DokuWiki and use the text ":SMILEYTEST:"
 ```
====== Test ======

===== Smiley =====

:SMILEYTEST:
```
  * Verify that the text ":SMILEYTEST:" and a generic icon appears
    * **If it was working correctly, the smiley image you saved would appear instead**
  * Create an interwiki folder as described in the official documentation: https://www.dokuwiki.org/interwiki
    * `config/dokuwiki/lib/images/interwiki`
  * Use your favorite paint program to create a 16x16 pixel red square and save it as ubuntu.png
    * Move it to the interwiki folder you created
  * Create a `config/dokuwiki/conf/interwiki.local.conf` file 
```
# Testing Interwiki's
ubuntu https://wiki.ubuntu.com/{NAME}
```
  * Edit your DokuWiki test page and add the text "[[ubuntu>teams|Ubuntu Teams]]"  
```
====== Test ======

===== Smiley =====

:SMILEYTEST:  

===== Interwiki =====

[[ubuntu>teams|Ubuntu Teams]]
```
  * Verify that a generic circle icon appears next to the interwiki link you created
    * **If it was working correctly, the red square icon you created would appear instead**
  * Build new (local) image from this PR.
  * Shut down and remove the existing container (but don't delete your persistent folders)
  * Clear the image cache: 
 ```
 rm -rf config/dokuwiki/data/cache/*/*.{gif,png,css}
```
  * Create and start up new container using the local image you just created
  * Go back to your DokuWiki test page
    * You may have to force refresh  
  * **The correct smiley image and red interwiki icon should now be visible**
  
## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
See issue #40.